### PR TITLE
Corrected typo in the Snickers example (40g --> 48g)

### DIFF
--- a/src/components/Instructions.jsx
+++ b/src/components/Instructions.jsx
@@ -30,7 +30,7 @@ export default function Instructions(){
                             <tr>
                                 <th className="td td--example-hilight">Typical Values</th>
                                 <th>Per 100g</th>
-                                <th className="td td--example-hilight">Per Serving Size (40g)</th>
+                                <th className="td td--example-hilight">Per Serving Size (48g)</th>
                             </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
Corrected the Snickers serving size from 40g to 48g.